### PR TITLE
gpio/aspeed: Use handler_data in aspeed_gpio_irq_handler.

### DIFF
--- a/drivers/gpio/gpio-aspeed.c
+++ b/drivers/gpio/gpio-aspeed.c
@@ -302,8 +302,8 @@ static int aspeed_gpio_set_type(struct irq_data *d, unsigned int type)
 
 static void aspeed_gpio_irq_handler(struct irq_desc *desc)
 {
+	struct aspeed_gpio *gpio = irq_desc_get_handler_data(desc);
 	struct irq_chip *chip = irq_desc_get_chip(desc);
-	struct aspeed_gpio *gpio = irq_desc_get_chip_data(desc);
 	unsigned int i, p, girq;
 	unsigned long reg;
 


### PR DESCRIPTION
In the port to 4.3, we converted to the newer irq api, but used the
chip_data for the struct aspeed_gpio pointer, rather than the
handler_data.

We use irq_set_chaned_handler_and_data to establish this pointer, which
sets handler_data. This change uses the appropriate pointer in our
handler instead.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>