### PR TITLE
aspeed: correct sram address in ast2400.dtsi

### DIFF
--- a/arch/arm/boot/dts/ast2400.dtsi
+++ b/arch/arm/boot/dts/ast2400.dtsi
@@ -79,9 +79,9 @@
 			#size-cells = <1>;
 			ranges;
 
-			sram@1e72000 {
+			sram@1e720000 {
 				compatible = "mmio-sram";
-				reg = <0x1e72000 0x8000>;	// 32K
+				reg = <0x1e720000 0x8000>;	// 32K
 			};
 
 			ibt@1e789140 {


### PR DESCRIPTION
Correct address of sram in ast2400.dtsi.