### PR TITLE
barreleye: Add gpio LEDs to device tree

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
@@ -1,6 +1,7 @@
 /dts-v1/;
 
 #include "ast2400.dtsi"
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	model = "Barrelye BMC";
@@ -37,6 +38,24 @@
 				};
 			};
 		};
+	};
+
+
+	leds {
+		compatible = "gpio-leds";
+
+		heartbeat {
+			gpios = <&gpio 140 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			gpios = <&gpio 141 GPIO_ACTIVE_LOW>;
+		};
+
+		identify {
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
 	};
 };
 

--- a/arch/arm/boot/dts/aspeed-bmc-opp-palmetto.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-palmetto.dts
@@ -1,6 +1,7 @@
 /dts-v1/;
 
 #include "ast2400.dtsi"
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	model = "Palmetto BMC";
@@ -30,5 +31,22 @@
 				};
 			};
 		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		heartbeat {
+			gpios = <&gpio 140 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			gpios = <&gpio 141 GPIO_ACTIVE_LOW>;
+		};
+
+		identify {
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
 	};
 };

--- a/arch/arm/boot/dts/ast2400.dtsi
+++ b/arch/arm/boot/dts/ast2400.dtsi
@@ -287,6 +287,8 @@
 			};
 
 			gpio: gpio@1e780000 {
+			       #gpio-cells = <2>;
+			       gpio-controller;
 			       compatible = "aspeed,ast2400-gpio";
 			       reg = <0x1e780000 0x1000>;
 			       interrupts = <20>;


### PR DESCRIPTION
This change exposes the LEDs (which are connected to GPIOs) on
barreleye and palmetto machines as led-class devices. This allows
us to use the full trigger support.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>