### PR TITLE
COMPILE_TEST Kconfig condition for ast2400 drivers

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -121,7 +121,7 @@ config GPIO_ALTERA
 
 config GPIO_ASPEED
 	bool "Aspeed AST2400 GPIO support"
-	depends on ARCH_ASPEED && OF
+	depends on (ARCH_ASPEED || COMPILE_TEST) && OF
 	select GENERIC_IRQ_CHIP
 	help
 	  Say Y here to support Aspeed AST2400 GPIO.

--- a/drivers/i2c/busses/Kconfig
+++ b/drivers/i2c/busses/Kconfig
@@ -976,7 +976,7 @@ config I2C_RCAR
 
 config I2C_ASPEED
 	tristate "Aspeed AST2xxx SoC I2C Controller"
-	depends on ARCH_ASPEED
+	depends on ARCH_ASPEED || COMPILE_TEST
 	select I2C_SLAVE
 	help
 	  If you say yes to this option, support will be included for the

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -580,7 +580,7 @@ config LPC18XX_WATCHDOG
 
 config ASPEED_24xx_WATCHDOG
 	tristate "Aspeed 23xx 24xx SoCs watchdog support"
-	depends on ARCH_ASPEED
+	depends on ARCH_ASPEED || COMPILE_TEST
 	select WATCHDOG_CORE
 	help
 	  Say Y here to include support for the watchdog timer


### PR DESCRIPTION
I generated this patch to build the ast2400 drivers into a Versatile kernel as part of an initial effort to bootstrap the development of the ast2400 device models in qemu. I figured it might be useful even though we didn't continue down that path (instead started working on emulating the ast2400 machine directly).