### PR TITLE
Disable internal AST RTC

### DIFF
--- a/arch/arm/boot/dts/ast2400.dtsi
+++ b/arch/arm/boot/dts/ast2400.dtsi
@@ -274,6 +274,7 @@
 			rtc: rtc@1e781000 {
 				compatible = "aspeed,rtc";
 				reg = <0x1e781000 0x18>;
+				status = "disabled";
 			};
 
 			timer: timer@98400000 {


### PR DESCRIPTION
The RTC implementation is system specific.  Some systems have external RTC circuits.  We only want one /dev/rtc for hwclock to use.   This disables the AST RTC which is not battery backed up so if an external RTC circuit is specified in system device tree, it will be assigned to /dev/rtc

Signed-off-by: Norman James <nkskjames@gmail.com>