### PR TITLE
[RFC] ncsi: Fix not releasing lock in ncsi_rcv_rsp()

### DIFF
--- a/drivers/i2c/busses/i2c-aspeed.c
+++ b/drivers/i2c/busses/i2c-aspeed.c
@@ -721,6 +721,7 @@ static int ast_i2c_probe_bus(struct platform_device *pdev)
 	}
 
 	/* Initialize the I2C adapter */
+	spin_lock_init(&bus->cmd_lock);
 	bus->adap.nr = bus_num;
 	bus->adap.owner = THIS_MODULE;
 	bus->adap.retries = 0;

--- a/net/ncsi/ncsi-rsp.c
+++ b/net/ncsi/ncsi-rsp.c
@@ -1154,7 +1154,6 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
 
 	nr->nr_rsp = skb;
 	if (!nr->nr_timer_enabled) {
-		spin_unlock_irqrestore(&ndp->ndp_req_lock, flags);
 		ret = -ENOENT;
 		goto out;
 	}
@@ -1163,6 +1162,7 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
 	ret = nrh->nrh_handler(nr);
 
 out:
+	spin_unlock_irqrestore(&ndp->ndp_req_lock, flags);
 	ncsi_free_req(nr, true, false);
 	return ret;
 }


### PR DESCRIPTION
I've found a locking problem which I believe might address issue #8. With this patch applied I also cannot reproduce #17.

I'm not sure this is the correct fix:
ncsi_free_req() takes ndp_req_lock again so this is 1 possible solution. Unfortunately I don't know the code enough to be sure it is safe to drop the lock before calling ncsi_free_req(), it is possible that dropping the lock could allow someone else to jump in and use the same nr possibly resulting in a double free.

Furthermore, after investigating other LOCKDEP issues I wrote that this patch:

```
commit e19be46436cc50cf6842d38fb5c44bca92ebb26f
Author: Cyril Bur <cyrilbur@gmail.com>
Date:   Thu Jan 21 11:30:26 2016 +1100

    i2c: aspeed spin_lock_init() on cmd_lock

diff --git a/drivers/i2c/busses/i2c-aspeed.c b/drivers/i2c/busses/i2c-aspeed.c
index 3b858d3..e4bf88a3 100644
--- a/drivers/i2c/busses/i2c-aspeed.c
+++ b/drivers/i2c/busses/i2c-aspeed.c
@@ -721,6 +721,7 @@ static int ast_i2c_probe_bus(struct platform_device *pdev)
        }
 
        /* Initialize the I2C adapter */
+       spin_lock_init(&bus->cmd_lock);
        bus->adap.nr = bus_num;
        bus->adap.owner = THIS_MODULE;
        bus->adap.retries = 0;
```

Breaks networking! I also found this extraordinarily hard to believe as well but it's absolutely the case. Please help understand why!