### PR TITLE
Fix polarity and names of LEDs

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
@@ -100,17 +100,14 @@
 		compatible = "gpio-leds";
 
 		heartbeat {
-			gpios = <&gpio 140 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
 		};
-
-		power {
-			gpios = <&gpio 141 GPIO_ACTIVE_LOW>;
-		};
-
 		identify {
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 58 GPIO_ACTIVE_LOW>;
 		};
-
+		beep {
+			gpios = <&gpio 111 GPIO_ACTIVE_HIGH>;
+		};
 	};
 };
 


### PR DESCRIPTION
Makes names consistent with schematic and correct polarity.

Signed-off-by: Norman James <nkskjames@gmail.com>