### PR TITLE
I2c : do not rename added devices, and a minor dtsi fix

### DIFF
--- a/arch/arm/boot/dts/ast2400.dtsi
+++ b/arch/arm/boot/dts/ast2400.dtsi
@@ -159,7 +159,7 @@
 					interrupts = <4>;
 				};
 
-				i2c5: i2c-bus@0x180 {
+				i2c5: i2c-bus@180 {
 					#address-cells = <1>;
 					#size-cells = <0>;
 					reg = <0x180 0x40>;


### PR DESCRIPTION

The documentation says you can't rename devices once they are added.

The commit log is a bit wide because I didn't wrap the cut & pasted comments from the code.

The code is a bit ugly looking for properties in the child to determine the name.

But there are rules!

Comments and alternatives welcome.

Also is a separate patch for the dtsi which I noticed while looking at the tree structure.

milton
