### PR TITLE
Remove GPIO and LPC from WDT reset list

### DIFF
--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -191,9 +191,10 @@ static void __init aspeed_init_early(void)
 	writel(0, AST_IO(AST_BASE_WDT | 0x2c));
 
 	/*
-	 * ensure all IPs are reset on watchdog expiry
+	 * ensure all IPs except GPIO and LPC are reset on watchdog expiry
 	 */
-	writel(0x003ffff3, AST_IO(AST_BASE_SCU | 0x9C));
+	writel(0x001fdff3, AST_IO(AST_BASE_SCU | 0x9C));
+	//writel(0x003ffff3, AST_IO(AST_BASE_SCU | 0x9C));
 
 	/*
 	 * Temporary setup of AST registers until pinmux driver is complete

--- a/drivers/watchdog/aspeed_wdt.c
+++ b/drivers/watchdog/aspeed_wdt.c
@@ -37,6 +37,7 @@ MODULE_DEVICE_TABLE(of, aspeed_wdt_of_table);
 #define WDT_RELOAD_VALUE	0x04
 #define WDT_RESTART		0x08
 #define WDT_CTRL		0x0C
+#define   WDT_CTRL_RESET_MODE_SOC	(0x00 << 5)
 #define   WDT_CTRL_RESET_MODE_FULL_CHIP	(0x01 << 5)
 #define   WDT_CTRL_RESET_SYSTEM		(0x1  << 1)
 #define   WDT_CTRL_ENABLE		(0x1  << 0)
@@ -45,7 +46,7 @@ MODULE_DEVICE_TABLE(of, aspeed_wdt_of_table);
 
 static void aspeed_wdt_enable(struct aspeed_wdt *wdt, int count)
 {
-	u32 ctrl = WDT_CTRL_RESET_MODE_FULL_CHIP | WDT_CTRL_RESET_SYSTEM |
+	u32 ctrl = WDT_CTRL_RESET_MODE_SOC | WDT_CTRL_RESET_SYSTEM |
 		WDT_CTRL_ENABLE;
 
 	writel(0, wdt->base + WDT_CTRL);


### PR DESCRIPTION
WDT reset mode must also be set to SOC mode.
This must be integrated with u-boot fix to move UART setup
outside of DRAM init.

Signed-off-by: Norman James <nkskjames@gmail.com>