### PR TITLE
Updated SCU88 register and SCU90 init values

### DIFF
--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -118,7 +118,7 @@ static void __init do_common_setup(void)
 	/* SCU setup */
 	writel(0x01C000FF, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0xC1C000FF, AST_IO(AST_BASE_SCU | 0x8c));
-	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));    
+	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));    
 	writel(0x003FA008, AST_IO(AST_BASE_SCU | 0x90));
 
 	/* Setup scratch registers */
@@ -139,6 +139,10 @@ static void __init do_barreleye_setup(void)
 	/* GPIO setup */
 	writel(0x9E82FCE7, AST_IO(AST_BASE_GPIO | 0x00));
 	writel(0x0370E677, AST_IO(AST_BASE_GPIO | 0x04));
+	
+	/* Barreleye SCU setup for PCIe Inventory */
+	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));    
+
 
 	/*
 	 * Do read/modify/write on power gpio to prevent resetting power on

--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -118,8 +118,8 @@ static void __init do_common_setup(void)
 	/* SCU setup */
 	writel(0x01C000FF, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0xC1C000FF, AST_IO(AST_BASE_SCU | 0x8c));
-	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));
-	writel(0x003FA009, AST_IO(AST_BASE_SCU | 0x90));
+	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));    
+	writel(0x003FA008, AST_IO(AST_BASE_SCU | 0x90));
 
 	/* Setup scratch registers */
 	writel(0x00000042, AST_IO(AST_BASE_LPC | 0x170));

--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -118,7 +118,7 @@ static void __init do_common_setup(void)
 	/* SCU setup */
 	writel(0x01C000FF, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0xC1C000FF, AST_IO(AST_BASE_SCU | 0x8c));
-	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));  
+	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0x003FA008, AST_IO(AST_BASE_SCU | 0x90));
 
 	/* Setup scratch registers */

--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -118,7 +118,7 @@ static void __init do_common_setup(void)
 	/* SCU setup */
 	writel(0x01C000FF, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0xC1C000FF, AST_IO(AST_BASE_SCU | 0x8c));
-	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));    
+	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));  
 	writel(0x003FA008, AST_IO(AST_BASE_SCU | 0x90));
 
 	/* Setup scratch registers */


### PR DESCRIPTION
This Patch was made to change init values for SCU registers:
1) SCU88 init value was changed
Reason:  For SCU88, bits 7:0 were set to 1. That meant, we were reading : PWMx / VPIGx instead of GPIONx (GPIONx gives us the PCIe inventory status, where x is bit number). But we were expecting PCIe inventory status (GOIONx) to show up on corresponding pin, and so it was being tied to read inventory via RESR API.  Because of this PCIe inventory was showing up wrong in Barreleye server. For correcting this this commit changes the value of bits 7:0 to 0. Since SCU88 seems to be specific to how board is wired, I added a step to reinitialize this register in device specific setup.

2) SCU90 init value was changed:
Reason: We were seeing intermittent networking failures since SD1 pin was wrongly pulled up. (corresponding to bit 0 of SCU90). So this commit changes bit 0 of SCU90 to 0.  

Description of pins 7:0 of SCU 88:
7 RW Enable PWM7 or VPIG7 function pin (SCU90[5:4]=0x2 select Video pin)
6 RW Enable PWM6 or VPIG6 function pin (SCU90[5:4]=0x2 select Video pin)
5 RW Enable PWM5 or VPIG5 function pin (SCU90[5:4]!=0 select Video pin)
4 RW Enable PWM4 or VPIG4 function pin (SCU90[5:4]!=0 select Video pin)
3 RW Enable PWM3 or VPIG3 function pin (SCU90[5:4]!=0 select Video pin)
2 RW Enable PWM2 or VPIG2 function pin (SCU90[5:4]!=0 select Video pin)
1 RW Enable PWM1 or VPIG1 function pin (SCU90[5:4]=0x3 select Video pin)
0 RW Enable PWM0 or VPIG0 function pin (SCU90[5:4]=0x3 select Video pin)

Signed-off-by: Adi Gangidi adi.gangidi@rackspace.com