### PR TITLE
Update SCU88 register and SCU90 init values

### DIFF
--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -118,8 +118,7 @@ static void __init do_common_setup(void)
 	/* SCU setup */
 	writel(0x01C000FF, AST_IO(AST_BASE_SCU | 0x88));
 	writel(0xC1C000FF, AST_IO(AST_BASE_SCU | 0x8c));
-	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));
-	writel(0x003FA009, AST_IO(AST_BASE_SCU | 0x90));
+	writel(0x003FA008, AST_IO(AST_BASE_SCU | 0x90));
 
 	/* Setup scratch registers */
 	writel(0x00000042, AST_IO(AST_BASE_LPC | 0x170));
@@ -139,7 +138,10 @@ static void __init do_barreleye_setup(void)
 	/* GPIO setup */
 	writel(0x9E82FCE7, AST_IO(AST_BASE_GPIO | 0x00));
 	writel(0x0370E677, AST_IO(AST_BASE_GPIO | 0x04));
-
+	
+	/* Barreleye Specific SCU setup */
+	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));
+	
 	/*
 	 * Do read/modify/write on power gpio to prevent resetting power on
 	 * reboot
@@ -164,6 +166,9 @@ static void __init do_palmetto_setup(void)
 	writel(0x0370E677, AST_IO(AST_BASE_GPIO | 0x04));
 	writel(0xDF48F7FF, AST_IO(AST_BASE_GPIO | 0x20));
 	writel(0xC738F202, AST_IO(AST_BASE_GPIO | 0x24));
+	
+	/* Palmetto Specific SCU setup */
+	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));
 }
 
 #define SCU_PASSWORD	0x1688A8A8


### PR DESCRIPTION
Before This change:
a) SCU90[0]=1, function pin Incorrectly defined. It must be pull down internally. Because of this networking has an intermittent failure
b) For SCU88, bits 7:0 were set to 1. That is: We were reading : PWMx or VPIGx instead of GPIONx (GPIONx gives us the PCIe inventory status, where x is bit number). Because of this PCIe inventory was showing up wrong in Barreleye server.

After This Change:
a) SCU90[0]=0 corrected
b) Bits (7:0) of SCU 88 are set to 0 . (According to Page 111 of data sheet these have to be set to 0 for us to to read GPION0 to GPIO N7 which indicate if PCIe device is present ). This is specific to Barreleye. Since SCU88 seems to be specific to how board is wired, I added a step to reinitialize this register in device specific setup.

Description of pins 0 of SCU 90:
Enable SD1 Function Pin

Description of pins 7:0 of SCU 88:
7 RW Enable PWM7 or VPIG7 function pin (SCU90[5:4]=0x2 select Video pin)
6 RW Enable PWM6 or VPIG6 function pin (SCU90[5:4]=0x2 select Video pin)
5 RW Enable PWM5 or VPIG5 function pin (SCU90[5:4]!=0 select Video pin)
4 RW Enable PWM4 or VPIG4 function pin (SCU90[5:4]!=0 select Video pin)
3 RW Enable PWM3 or VPIG3 function pin (SCU90[5:4]!=0 select Video pin)
2 RW Enable PWM2 or VPIG2 function pin (SCU90[5:4]!=0 select Video pin)
1 RW Enable PWM1 or VPIG1 function pin (SCU90[5:4]=0x3 select Video pin)
0 RW Enable PWM0 or VPIG0 function pin (SCU90[5:4]=0x3 select Video pin)

Signed-off-by: Adi Gangidi adi.gangidi@rackspace.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/linux/69)
<!-- Reviewable:end -->
