### PR TITLE
Removed firestone from dt makefile.

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -779,8 +779,7 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += \
 dtb-$(CONFIG_ARCH_ZX) += zx296702-ad1.dtb
 dtb-$(CONFIG_MACH_OPP_PALMETTO_BMC) += \
 	aspeed-bmc-opp-palmetto.dtb \
-	aspeed-bmc-opp-barreleye.dtb \
-	aspeed-bmc-opp-firestone.dtb
+	aspeed-bmc-opp-barreleye.dtb
 endif
 
 dtstree		:= $(srctree)/$(src)


### PR DESCRIPTION
There isn't any firestone dts to compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/linux/72)
<!-- Reviewable:end -->
