### PR TITLE
Basic support for the Garrison system

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -779,7 +779,8 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += \
 dtb-$(CONFIG_ARCH_ZX) += zx296702-ad1.dtb
 dtb-$(CONFIG_MACH_OPP_PALMETTO_BMC) += \
 	aspeed-bmc-opp-palmetto.dtb \
-	aspeed-bmc-opp-barreleye.dtb
+	aspeed-bmc-opp-barreleye.dtb \
+	aspeed-bmc-opp-garrison.dtb
 endif
 
 dtstree		:= $(srctree)/$(src)

--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -779,8 +779,7 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += \
 dtb-$(CONFIG_ARCH_ZX) += zx296702-ad1.dtb
 dtb-$(CONFIG_MACH_OPP_PALMETTO_BMC) += \
 	aspeed-bmc-opp-palmetto.dtb \
-	aspeed-bmc-opp-barreleye.dtb \
-	aspeed-bmc-opp-firestone.dtb
+	aspeed-bmc-opp-barreleye.dtb
 endif
 
 dtstree		:= $(srctree)/$(src)

--- a/arch/arm/boot/dts/aspeed-bmc-opp-garrison.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-garrison.dts
@@ -1,0 +1,80 @@
+/dts-v1/;
+
+#include "ast2400.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "Garrison BMC";
+	compatible = "ibm,garrison-bmc", "aspeed,ast2400";
+
+	ahb {
+		fmc@1e620000 {
+			reg = < 0x1e620000 0x94
+				0x20000000 0x02000000 >;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "aspeed,fmc";
+			flash@0 {
+				reg = < 0 >;
+				compatible = "jedec,spi-nor" ;
+				/*
+				 * Possibly required props:
+				 * spi-max-frequency = <>
+				 * spi-tx-bus-width = <>
+				 * spi-rx-bus-width  = <>
+				 * m25p,fast-read
+				 * spi-cpol if inverse clock polarity (CPOL)
+				 * spi-cpha if shifted clock phase (CPHA)
+				 */
+#include "aspeed-bmc-opp-flash-layout.dtsi"
+			};
+		};
+		spi@1e630000 {
+			reg = < 0x1e630000 0x18
+				0x30000000 0x02000000 >;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "aspeed,smc";
+			flash {
+				reg = < 0 >;
+				compatible = "jedec,spi-nor" ;
+				label = "pnor";
+				/* spi-max-frequency = <>; */
+				/* m25p,fast-read; */
+			};
+		};
+		apb {
+			i2c: i2c@1e78a040 {
+				i2c4: i2c-bus@140 {
+					occ@50 {
+						compatible = "ibm,occ-i2c";
+						reg = <0x50>;
+					};
+				};
+				i2c5: i2c-bus@180 {
+					occ@50 {
+						compatible = "ibm,occ-i2c";
+						reg = <0x50>;
+					};
+				};
+				i2c10: i2c-bus@3c0 {
+					status = "okay";
+				};
+				i2c11: i2c-bus@400 {
+					status = "okay";
+
+					rtc@68 {
+						compatible = "dallas,ds3231";
+						reg = <0x68>;
+					};
+				};
+				i2c12: i2c-bus@440 {
+					status = "okay";
+				};
+				i2c13: i2c-bus@480 {
+					status = "okay";
+				};
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/ast2400.dtsi
+++ b/arch/arm/boot/dts/ast2400.dtsi
@@ -215,7 +215,9 @@
 				};
 
 				i2c10: i2c-bus@3c0 {
-					reg = <0x380 0x40>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					reg = <0x3C0 0x40>;
 					compatible = "aspeed,ast2400-i2c-bus";
 					bus = <10>;
 					clock-frequency = <100000>;
@@ -224,6 +226,8 @@
 				};
 
 				i2c11: i2c-bus@400 {
+					#address-cells = <1>;
+					#size-cells = <0>;
 					reg = <0x400 0x40>;
 					compatible = "aspeed,ast2400-i2c-bus";
 					bus = <11>;
@@ -235,7 +239,7 @@
 				i2c12: i2c-bus@440 {
 					#address-cells = <1>;
 					#size-cells = <0>;
-					reg = <0x400 0x40>;
+					reg = <0x440 0x40>;
 					compatible = "aspeed,ast2400-i2c-bus";
 					bus = <12>;
 					clock-frequency = <100000>;

--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -171,6 +171,18 @@ static void __init do_palmetto_setup(void)
 	writel(0x01C0007F, AST_IO(AST_BASE_SCU | 0x88));
 }
 
+static void __init do_garrison_setup(void)
+{
+	do_common_setup();
+
+	/* Setup PNOR address mapping for 64M flash */
+	writel(0x30000C00, AST_IO(AST_BASE_LPC | 0x88));
+	writel(0xFC0003FF, AST_IO(AST_BASE_LPC | 0x8C));
+
+	/* SCU setup */
+	writel(0xd7000000, AST_IO(AST_BASE_SCU | 0x88));
+}
+
 #define SCU_PASSWORD	0x1688A8A8
 
 static void __init aspeed_init_early(void)
@@ -207,6 +219,9 @@ static void __init aspeed_init_early(void)
 		do_barreleye_setup();
 	if (of_machine_is_compatible("tyan,palmetto-bmc"))
 		do_palmetto_setup();
+	if (of_machine_is_compatible("ibm,garrison-bmc"))
+		do_garrison_setup();
+
 }
 
 static void __init aspeed_map_io(void)


### PR DESCRIPTION
A couple base ast2400 dtsi fixes for i2c.
Basic device tree for Garrison system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/linux/76)
<!-- Reviewable:end -->
