### PR TITLE
Add motherboard eeprom located at i2c4 address 0xA8

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
@@ -82,6 +82,11 @@
 						reg = <0x10>;
 						sense-resistor = <500>;
 					};
+					eeprom@54 {
+						compatible = "atmel,24c256";
+						reg = <0x54>;
+						pagesize = <64>;
+					};
 				};
 				i2c5: i2c-bus@180 {
 					adm1278@10 {


### PR DESCRIPTION
The motherbaord eeprom in Barreleye is accessible through i2c4
address 0xA8 (54). Adding it to the device tree since its vpd
contains the system UUID which is needed to be added to the
inventory.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>