### PR TITLE
Add FMC and phosphor flash layout to AST2500 EVB dts

### DIFF
--- a/arch/arm/boot/dts/aspeed-ast2500-evb.dts
+++ b/arch/arm/boot/dts/aspeed-ast2500-evb.dts
@@ -18,6 +18,21 @@
 	memory {
 		reg = <0x80000000 0x20000000>;
 	};
+
+	ahb {
+		bmc_pnor: fmc@1e620000 {
+			reg = < 0x1e620000 0x94
+				0x20000000 0x02000000 >;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "aspeed,fmc";
+			flash@0 {
+				reg = < 0 >;
+				compatible = "jedec,spi-nor" ;
+#include "aspeed-bmc-opp-flash-layout.dtsi"
+			};
+		};
+	};
 };
 
 &uart5 {


### PR DESCRIPTION
with MTD kernel support, the boot now shows

[    2.740000] Creating 6 MTD partitions on "bmc":
[    2.900000] 0x000000000000-0x000000060000 : "u-boot"
[    2.900000] 0x000000060000-0x000000080000 : "u-boot-env"
[    2.900000] 0x000000080000-0x000000300000 : "kernel"
[    2.900000] 0x000000300000-0x0000004c0000 : "initramfs"
[    2.900000] 0x0000004c0000-0x000001c00000 : "rofs"
[    2.900000] 0x000001c00000-0x000002000000 : "rwfs"