### PR TITLE
Fix the incorrect debounce setting on power button

### DIFF
--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -159,9 +159,9 @@ static void __init do_barreleye_setup(void)
 	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x48));
 	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x4C));
 
-	/* Set debounce timer to 480000 cycles, with a pclk of 24MHz,
+	/* Set debounce timer to 480000 cycles, with a pclk of 48MHz,
 	 * corresponds to 20 ms. This time was found by experimentation */
-	writel(0x00075300, AST_IO(AST_BASE_GPIO | 0x58));
+	writel(0x000EA600, AST_IO(AST_BASE_GPIO | 0x58));
 }
 
 static void __init do_palmetto_setup(void)


### PR DESCRIPTION
PCLK divider selection is decided by SCU08[25:23] and the value is 011b
on Barreleye.
That means PCLK should be H-PLL/8=384MHz/8=48MHz, but the current
debounce timer value was computed by 24MHz.
So the correct value should be 20ms*48000000/1000=EA600h

Signed-off-by: johnhcwang <hsienchiang@gmail.com>