### PR TITLE
boot/dts: Keep the LED initial state during kernel loading

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-opp-barreleye.dts
@@ -132,12 +132,15 @@
 
 		heartbeat {
 			gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 		identify {
 			gpios = <&gpio 58 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
 		};
 		beep {
 			gpios = <&gpio 111 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 	};
 };


### PR DESCRIPTION
Base on the Barreleye HW spec, the beep LED shouldn't be
turned to OFF until BMC ready.

Now the LED will be turned to OFF when the kernel loading,
so enable the LED sub-node property "default-state" to keep the LED
initial state.

Signed-off-by: johnhcwang hsienchiang@gmail.com
