### PR TITLE
disable acpi function when config acpi pin

### DIFF
--- a/drivers/pinctrl/aspeed/pinctrl-aspeed.c
+++ b/drivers/pinctrl/aspeed/pinctrl-aspeed.c
@@ -207,7 +207,7 @@ static int aspeed_sig_expr_set(const struct aspeed_sig_expr *expr,
 		 * reset.
 		 */
 		if (desc->ip == ASPEED_IP_SCU && desc->reg == HW_STRAP1 &&
-		    !(desc->mask & (BIT(21) | BIT(22))))
+		    !(desc->mask & (BIT(21) | BIT(22) | BIT(19))))
 			continue;
 
 		if (desc->ip == ASPEED_IP_SCU && desc->reg == HW_STRAP2)


### PR DESCRIPTION
## example set P21 to GPIOY3

the mux pin config 

```c
SIG_EXPR_DECL(SIOPWREQ, SIOPWREQ, SIG_DESC_SET(SCUA4, 10));
SIG_EXPR_DECL(SIOPWREQ, ACPI, ACPI_DESC);
SIG_EXPR_LIST_DECL_DUAL(SIOPWREQ, SIOPWREQ, ACPI);
SIG_EXPR_LIST_DECL_SINGLE(DASHP22, DASHP22, SIG_DESC_SET(SCU94, 11));

MS_PIN_DECL(P21, GPIOY3, SIOONCTRL, DASHP21); //MS_PIN_DECL(pin, other, high, low)
```

when set the pin, should disable the FUNCTION ACPI ,the function `aspeed_sig_expr_set` do it

```c
 if (desc->ip == ASPEED_IP_SCU && desc->reg == HW_STRAP1 &&
                     !(desc->mask & (BIT(21) | BIT(22))))   //skip,so can not disable acpi
                          continue;
```



i change it to 

```c
 if (desc->ip == ASPEED_IP_SCU && desc->reg == HW_STRAP1 &&
~                     !(desc->mask & (BIT(21) | BIT(22) | BIT(19))))
                          continue;
```

