### PR TITLE
Add i2c seeproms for Rainier system

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts
@@ -53,6 +53,11 @@
 
 &i2c0 {
 	status = "okay";
+
+        eeprom@50 {
+                compatible = "atmel,24c64";
+                reg = <0x50>;
+        };
 };
 
 &i2c1 {
@@ -262,6 +267,16 @@
 		reg = <0x76>;
 		#io-channel-cells = <0>;
 	};
+
+        eeprom@50 {
+                compatible = "atmel,24c64";
+                reg = <0x50>;
+        };
+
+        eeprom@51 {
+                compatible = "atmel,24c64";
+                reg = <0x51>;
+        };
 };
 
 &i2c8 {
@@ -296,6 +311,16 @@
 		compatible = "ti,tmp275";
 		reg = <0x4a>;
 	};
+
+        eeprom@50 {
+                compatible = "atmel,24c64";
+                reg = <0x50>;
+        };
+
+        eeprom@51 {
+                compatible = "atmel,24c64";
+                reg = <0x51>;
+        };
 };
 
 &i2c9 {
@@ -340,6 +365,11 @@
 		compatible = "infineon,ir35221";
 		reg = <0x74>;
 	};
+
+        eeprom@50 {
+                compatible = "atmel,24c64";
+                reg = <0x50>;
+        };
 };
 
 &i2c10 {
@@ -384,6 +414,11 @@
 		compatible = "infineon,ir35221";
 		reg = <0x74>;
 	};
+        eeprom@50 {
+                compatible = "atmel,24c64";
+                reg = <0x50>;
+        };
+
 };
 
 &i2c11 {


### PR DESCRIPTION
Added seproms for for the below VPD devices
- BMC
- TPM
- System Planar
- DCM 0 VRM
- DCM 1 VRM 
- Base Op panel
- Lcd Op panel