### PR TITLE
net: nuvoton: emc: Fix: some failed phy functions did not return error

### DIFF
--- a/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
+++ b/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
@@ -1801,7 +1801,8 @@ static int npcm7xx_mii_setup(struct net_device *dev)
 	writel(readl((ether->reg + REG_MCMDR)) | MCMDR_ENMDC,
 	       (ether->reg + REG_MCMDR));
 
-	if (mdiobus_register(ether->mii_bus)) {
+	err = mdiobus_register(ether->mii_bus);
+	if (err) {
 		dev_err(&pdev->dev, "mdiobus_register() failed\n");
 		goto out2;
 	}
@@ -1809,6 +1810,7 @@ static int npcm7xx_mii_setup(struct net_device *dev)
 	phydev = phy_find_first(ether->mii_bus);
 	if (!phydev) {
 		dev_err(&pdev->dev, "phy_find_first() failed\n");
+		err = -ENODEV;
 		goto out3;
 	}
 


### PR DESCRIPTION
Fix: before this fix when mdiobus_register() or phy_find_first() failed the function did not return error.